### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-phpwomen.org.br


### PR DESCRIPTION
Estamos publicando uma outra versão do site do PHPWomenBR no gh-pages e precisamos que este CNAME seja removido.